### PR TITLE
Lots of improvements to the rents_basic and rents_advanced work flow,

### DIFF
--- a/app/dao/common.py
+++ b/app/dao/common.py
@@ -4,9 +4,9 @@ from flask import request
 from flask_login import current_user
 from sqlalchemy.orm import load_only
 from app.dao.database import commit_to_database
-from app.models import Agent, Case, Charge, ChargeType, Date_m, DocFile, DigFile, EmailAcc, FormLetter, Jstore, \
+from app.models import Agent, Case, Charge, ChargeType, DocFile, DigFile, EmailAcc, FormLetter, Jstore, \
     Income, IncomeAlloc, Landlord, LeaseUpType, Loan, MoneyItem, Property, PrCharge, PrHistory, \
-    Rent, RentExternal, MoneyAcc, TypeDeed, TypeDoc
+    Rent, MoneyAcc, TypeDeed, TypeDoc
 
 
 def delete_record(item_id, item):

--- a/app/dao/rent.py
+++ b/app/dao/rent.py
@@ -66,6 +66,19 @@ def getrents_basic(filtr):        # simple filtered rents for main rents page
         .filter(*filtr).order_by(Rent.rentcode).limit(30).all()
 
 
+def getrents_basic_sam(filtr):  # simple filtered rents for main rents page using join to prop_rent
+    return db.session.query(Rent).join(Property) \
+        .options(load_only('id', 'rentcode', 'arrears', 'datecode_id', 'freq_id', 'lastrentdate',
+                           'rentpa', 'source', 'status_id', 'tenantname'),
+                 joinedload('agent').load_only('detail'),
+                 joinedload('prop_rent').options(load_only('propaddr'))) \
+        .filter(*filtr).order_by(Rent.rentcode).limit(30).all()
+
+
+def getrents_basic_sql(sql):  # simple filtered rents for main rents page using raw sql
+    return db.session.execute(sql).fetchall()
+
+
 def getrents_advanced(filtr, runsize):    # filtered rents for advanced queries and payrequest pages
     return db.session.query(Rent).join(Property) \
         .options(load_only('id', 'advarr_id', 'arrears', 'freq_id', 'lastrentdate',

--- a/app/main/common.py
+++ b/app/main/common.py
@@ -1,8 +1,9 @@
 # common.py - attempt to put all commonly used non db stuff here and in functions.py
 from flask import current_app
 from dateutil.relativedelta import relativedelta
+from app import app
 from app.models import Jstore, Landlord, TypeDeed
-from app.modeltypes import AcTypes, AdvArr, Date_m, Freqs, MailTos, PrDeliveryTypes, SaleGrades, Statuses, Tenures
+from app.modeltypes import Date_m
 
 
 def get_combodict_basic():
@@ -99,3 +100,30 @@ def inc_date_m(date1, frequency, datecode_id, periods):
         current_app.logger.warn(f"inc_date_m(): Unexpected 'date2' ({date2})")
 
     return date2
+
+
+@app.context_processor
+def date_processor():
+    def next_rent_date(date1, frequency, datecode_id, periods):
+        # first we get a new pure date calculated forwards or backwards for the number of periods
+        date2 = inc_date(date1, frequency, periods)
+        if datecode_id != 0:
+            if frequency not in (2, 4):
+                current_app.logger.warn(f"inc_date_m(): Unexpected 'frequency' ({frequency})")
+            # now get special date sequences from date_m model type
+            dates_m = Date_m.get_dates(datecode_id)
+            for item in dates_m:
+                if item[0] == date2.month:
+                    return date2.replace(day=item[1])
+            current_app.logger.warn(f"inc_date_m(): Unexpected 'date2' ({date2})")
+
+        return date2
+
+    return dict(next_rent_date=next_rent_date)
+#
+#
+# @app.context_processor
+# def utility_processor():
+#     def format_price(amount, currency=u'€'):
+#         return u'{0:.2f}{1}'.format(amount, currency)
+#     return dict(format_price=format_price)

--- a/app/main/headrent.py
+++ b/app/main/headrent.py
@@ -2,7 +2,6 @@ from flask import request
 from app.dao.agent import get_agent_id
 from app.dao.headrent import get_headrents, post_headrent
 from app.dao.landlord import get_landlord_id
-from app.main.common import inc_date_m
 from app.main.functions import strToDec
 from app.models import Agent, Headrent
 from app.modeltypes import AdvArr, Freqs, HrStatuses, SaleGrades, Tenures
@@ -40,7 +39,6 @@ def get_headrents_p():
         filter.append(Headrent.status_id==1)
     headrents = get_headrents(filter)
     for headrent in headrents:
-        headrent.nextrentdate = inc_date_m(headrent.lastrentdate, headrent.freq_id, headrent.datecode_id, 1)
         headrent.status = HrStatuses.get_name(headrent.status_id)
 
     return filterdict, headrents

--- a/app/main/loan.py
+++ b/app/main/loan.py
@@ -82,6 +82,16 @@ def get_loan_stat(loan_id):
         item_row = {'id': 0, 'date': int_date, 'memo': f"interest added {freqdet}", 'amount': 0, 'rate': 0, 'interest': 0, 'addinterest': 'yes', 'balance': 0}
         loanstatement.append(item_row)
         int_date = inc_date(int_date, loan.freq_id, 1)
+    rate = rates[0]
+    bal = loanstatement[0].get('amount')
+    interest_pending = 0
+    for row in loanstatement:
+        row['rate'] = rate
+        row['interest'] = rate * (stat_date - row['date']).days / 365.25
+        interest_pending = interest_pending + row['interest']
+        if row['add interest'] == 'yes':
+            row['balance'] = bal + interest_pending
+            interest_pending = 0
     loanstatement = sorted(loanstatement, key=lambda k: k['date'])
 
     return checksums, loancode, loanstatement

--- a/app/main/rent_filter.py
+++ b/app/main/rent_filter.py
@@ -1,89 +1,132 @@
 from datetime import date
 from dateutil.relativedelta import relativedelta
 from flask import request
-from app.main.functions import strToDate
 from app.models import Agent, Property, Rent
 from app.modeltypes import AcTypes, PrDeliveryTypes, SaleGrades, Statuses, Tenures
 
 
-def filter_advanced(dict):
-    fdict, filtr = filter_basic(dict)   # gets interpreted filter for basic dict keys
-    # now unpack filter values for the additional dict keys
+def dict_basic():
+    return {'agentdetail': request.form.get('agentdetail') or "",
+            'propaddr': request.form.get('propaddr') or "",
+            'rentcode': request.form.get('rentcode') or "",
+            'source': request.form.get('source') or "",
+            'tenantname': request.form.get('tenantname') or ""
+            }
+
+
+def dict_advanced():
+    dict = dict_basic()
     dict['actype'] = request.form.getlist('actype') or ['all actypes']
-    if dict['actype'] and dict['actype'] != [] and dict['actype'] != ['all actypes']:
+    dict['agentmailto'] = request.form.get('agentmailto') or 'include'
+    dict['emailable'] = request.form.get('emailable') or 'include'
+    dict['enddate'] = request.form.get('enddate') or date.today() + relativedelta(days=50)
+    dict['landlord'] = request.form.getlist('landlord') or ['all landlords']
+    dict['prdelivery'] = request.form.getlist('prdelivery') or ['all prdeliveries']
+    dict['salegrade'] = request.form.getlist('salegrade') or ['all salegrades']
+    dict['status'] = request.form.getlist('status') or ['all statuses']
+    dict['tenure'] = request.form.getlist('tenure') or ['all tenures']
+
+    return dict
+
+
+def filter_advanced(dict):
+    filtr = filter_basic(dict)
+    # first resolve basic dict keys and then deal with advanced dict keys
+    if dict['actype'] and dict['actype'] != ['all actypes']:
         ids = []
         for i in range(len(dict['actype'])):
             ids.append(AcTypes.get_id(dict['actype'][i]))
         filtr.append(Rent.actype_id.in_(ids))
-    dict['agentmailto'] = request.form.get('agentmailto') or 'include'
     if dict['agentmailto'] and dict['agentmailto'] == "exclude":
         filtr.append(Rent.mailto_id.notin_(1, 2))
     elif dict['agentmailto'] and dict['agentmailto'] == "only":
         filtr.append(Rent.mailto_id.in_(1, 2))
-        # elif key == "arrears" and value and value != "":
-        #     filtr.append(Rent.arrears == strToDec('{}'.format(value)))
-        # I will get to this when I do
-        # elif key == "charges" and value == "exclude":
-        #     filtr.append(Rent.mailto_id.notin_(1, 2))
-        # elif key == "charges" and value == "only":
-        #     filtr.append(Rent.mailto_id.in_(1, 2))
-        # elif key == "emailable" and value == "exclude":
-        #     filtr.append(Rent.mailto_id.notin_(1, 2))
-        # elif key == "emailable" and value == "only":
-        #     filtr.append(Rent.mailto_id.in_(1, 2))
-        dict['enddate'] = request.form.get('enddate') or date.today() + relativedelta(days=50)
-        filtr.append(Rent.lastrentdate <= strToDate('{}'.format(dict['enddate'])))
-        dict['landlord'] = request.form.getlist('landlord') or ['all landlords']
-        if dict['landlord'] and dict['landlord'] != [] and dict['landlord'] != ['all landlords']:
-            filtr.append(Rent.name.in_(dict['landlord']))
-        dict['prdelivery'] = request.form.getlist('prdelivery') or ['all prdeliveries']
-        if dict['prdelivery'] and dict['prdelivery'] != [] and dict['prdelivery'] != ['all prdeliveries']:
-            ids = []
-            for i in range(len(dict['prdelivery'])):
-                ids.append(PrDeliveryTypes.get_id(dict['prdelivery'][i]))
-            filtr.append(Rent.prdelivery_id.in_(ids))
-        # elif key == "rentpa" and value and value != "":
-        #     filtr.append(Rent.rentpa == strToDec('{}'.format(value)))
-        # elif key == "rentperiods" and value and value != "":
-        #     filtr.append(Rent.rentpa == strToDec('{}'.format(value)))
-        dict['salegrade'] = request.form.getlist('salegrade') or ['all salegrades']
-        if dict['salegrade'] and dict['salegrade'] != [] and dict['salegrade'] != ['all salegrades']:
-            ids = []
-            for i in range(len(dict['salegrade'])):
-                ids.append(SaleGrades.get_id(dict['salegrade'][i]))
-            filtr.append(Rent.salegrade_id.in_(ids))
-        dict['status'] = request.form.getlist('status') or ['all statuses']
-        if dict['status'] and dict['status'] != [] and dict['status'] != ['all statuses']:
-            ids = []
-            for i in range(len(dict['status'])):
-                ids.append(Statuses.get_id(dict['status'][i]))
-            filtr.append(Rent.status_id.in_(ids))
-        dict['tenure'] = request.form.getlist('tenure') or ['all tenures']
-        if dict['tenure'] and dict['tenure'] != [] and dict['tenure'] != ['all tenures']:
-            ids = []
-            for i in range(len(dict['tenure'])):
-                ids.append(Tenures.get_id(dict['tenure'][i]))
-            filtr.append(Rent.tenure_id.in_(ids))
+    #     todo
+    # elif key == "arrears" and value and value != "":
+    #     filtr.append(Rent.arrears == strToDec('{}'.format(value)))
+    # elif key == "charges" and value == "exclude":
+    #     filtr.append(Rent.mailto_id.notin_(1, 2))
+    # elif key == "charges" and value == "only":
+    #     filtr.append(Rent.mailto_id.in_(1, 2))
+    # elif dict['emailable'] and dict['emailable'] == "exclude":
+    #     filtr.append(Rent.mailto_id.notin_(1, 2))
+    # elif dict['emailable'] and dict['emailable'] == "only":
+    #     filtr.append(Rent.mailto_id.in_(1, 2))
+    # elif key == "rentpa" and value and value != "":
+    #     filtr.append(Rent.rentpa == strToDec('{}'.format(value)))
+    # elif key == "rentperiods" and value and value != "":
+    #     filtr.append(Rent.rentpa == strToDec('{}'.format(value)))
+    filtr.append(Rent.lastrentdate <= dict['enddate'])
+    if dict['landlord'] and dict['landlord'] != ['all landlords']:
+        filtr.append(Rent.name.in_(dict['landlord']))
+    if dict['prdelivery'] and dict['prdelivery'] != ['all prdeliveries']:
+        ids = []
+        for i in range(len(dict['prdelivery'])):
+            ids.append(PrDeliveryTypes.get_id(dict['prdelivery'][i]))
+        filtr.append(Rent.prdelivery_id.in_(ids))
+    if dict['salegrade'] and dict['salegrade'] != ['all salegrades']:
+        ids = []
+        for i in range(len(dict['salegrade'])):
+            ids.append(SaleGrades.get_id(dict['salegrade'][i]))
+        filtr.append(Rent.salegrade_id.in_(ids))
+    if dict['status'] and dict['status'] != ['all statuses']:
+        ids = []
+        for i in range(len(dict['status'])):
+            ids.append(Statuses.get_id(dict['status'][i]))
+        filtr.append(Rent.status_id.in_(ids))
+    if dict['tenure'] and dict['tenure'] != ['all tenures']:
+        ids = []
+        for i in range(len(dict['tenure'])):
+            ids.append(Tenures.get_id(dict['tenure'][i]))
+        filtr.append(Rent.tenure_id.in_(ids))
 
-    return dict, filtr
+    return filtr
 
 
 def filter_basic(dict):
     filtr = []
-    dict['agentdetail'] = request.form.get('agentdetail') or ''
-    dict['propaddr'] = request.form.get('propaddr') or ''
-    dict['rentcode'] = request.form.get('rentcode') or ''
-    dict['source'] = request.form.get('source') or ''
-    dict['tenantname'] = request.form.get('tenantname') or ''
-    if dict.get('agentdetail') and dict.get('agentdetail') != "":
+    # create simple filter for rents (home) and rents external pages
+    if dict.get('agentdetail'):
         filtr.append(Agent.detail.ilike('%{}%'.format(dict.get('agentdetail'))))
-    if dict.get('propaddr') and dict.get('propaddr') != "":
+    if dict.get('propaddr'):
         filtr.append(Property.propaddr.ilike('%{}%'.format(dict.get('propaddr'))))
-    if dict.get('rentcode') and dict.get('rentcode') != "":
+    if dict.get('rentcode'):
         filtr.append(Rent.rentcode.startswith([dict.get('rentcode')]))
-    if dict.get('source') and dict.get('source') != "":
+    if dict.get('source'):
         filtr.append(Rent.source.ilike('%{}%'.format(dict.get('source'))))
-    if dict.get('tenantname') and dict.get('tenantname') != "":
+    if dict.get('tenantname'):
         filtr.append(Rent.tenantname.ilike('%{}%'.format(dict.get('tenantname'))))
 
-    return dict, filtr
+    return filtr
+
+
+def filter_basic_sql_1():
+    return """ SELECT r.id, r.rentcode, r.tenantname, r.rentpa, r.arrears, r.lastrentdate, r.source, r.status_id, 
+                r.freq_id, r.datecode_id, a.detail,
+                (SELECT GROUP_CONCAT(DISTINCT propaddr SEPARATOR '; ')
+                FROM property 
+                WHERE rent_id = r.id 
+                GROUP BY rent_id) as propaddr
+                FROM rent r 
+                LEFT JOIN agent a 
+                ON a.id = r.agent_id 
+                LEFT JOIN property p 
+                ON p.rent_id = r.id """
+
+
+def filter_basic_sql_2(dict, id_list):
+    if id_list:
+        sql2 = " r.id IN {}".format(tuple(id_list))
+    else:
+        agentdetail_sql = " a.detail LIKE '%{}%' ".format(dict.get('agentdetail')) if dict.get('agentdetail') else ""
+        # todo additional filter for amount owing:  owingSql = " {} <= Owing AND
+        #  Owing <= {}".format(owing - money(0.03), owing + money(0.03)) if owing is not None else ""
+        propaddr_sql = " propaddr LIKE '%{}%' ".format(dict.get('propaddr')) if dict.get('propaddr') else ""
+        rentcode_sql = " r.rentcode LIKE '{}%' ".format(dict.get('rentcode')) if dict.get('rentcode') else ""
+        source_sql = " r.source LIKE '%{}%' ".format(dict.get('source')) if dict.get('source') else ""
+        tenantname_sql = " r.tenantname LIKE '%{}%' ".format(dict.get('tenantname')) if dict.get('tenantname') else ""
+        sql2 = " AND " \
+            .join([sql for sql in [rentcode_sql, tenantname_sql, source_sql, agentdetail_sql, propaddr_sql] if sql])
+    sql2 = "WHERE " + sql2 + " GROUP BY r.id LIMIT 50" if sql2 else " GROUP BY r.id LIMIT 50"
+
+    return sql2

--- a/app/models.py
+++ b/app/models.py
@@ -55,16 +55,6 @@ class ChargeType(db.Model):
     incomealloc_chargetype = db.relationship('IncomeAlloc', backref='chargetype', lazy='dynamic')
 
 
-class Date_m(db.Model):
-    __tablename__ = 'date_m'
-
-    id = db.Column(db.Integer, primary_key=True)
-    code = db.Column(db.String(15))
-    month = db.Column(db.Integer)
-    day = db.Column(db.Integer)
-    code_id = db.Column(db.Integer)
-
-
 class DigFile(db.Model):
     __tablename__ = 'digfile'
 
@@ -483,7 +473,7 @@ class Rent(db.Model):
     event_rent = db.relationship('Event', backref='rent', lazy='dynamic')
     incomealloc_rent = db.relationship('IncomeAlloc', backref='rent', lazy='dynamic')
     lease_rent = db.relationship('Lease', backref='rent', lazy='dynamic')
-    prop_rent = db.relationship('Property', backref='rent', lazy='dynamic')
+    prop_rent = db.relationship('Property', backref='rent')
     payrequest_rent = db.relationship('PrHistory', backref='rent', lazy='dynamic')
 
     def __repr__(self):

--- a/app/templates/headrent.html
+++ b/app/templates/headrent.html
@@ -76,7 +76,8 @@
         <div class="col-md-2">
             <label for="nextrentdate">next rent date:</label>
             <input type="date" class="form-control" name="nextrentdate"
-                   value="{{ nextrentdate }}" readonly="true">
+                   value="{{ next_rent_date(headrent.lastrentdate, headrent.freq_id,
+                        headrent.datecode_id, 1).strftime('%d-%b-%Y') }}" readonly="true">
         </div>
     </div>
     <div class="form-group row flex-row-reverse">

--- a/app/templates/headrents.html
+++ b/app/templates/headrents.html
@@ -27,7 +27,8 @@
                     <td style="width: 10.00%">{{ item.code }}</td>
                     <td style="width: 8.00%"> {{ item.rentpa }}</td>
                     <td style="width: 7.00%"> {{ item.arrears }}</td>
-                    <td style="width: 13.00%"> {{ item.nextrentdate.strftime('%d-%b-%Y') }}</td>
+                    <td style="width: 13.00%"> {{ next_rent_date(item.lastrentdate, item.freq_id,
+                        item.datecode_id, 1).strftime('%d-%b-%Y') }}</td>
                     <td style="width: 26.00%">{{ item.propaddr }}</td>
                     <td style="width: 4.00%"> {{ item.freq_id }}</td>
                     <td style="width: 8.00%"> {{ item.status }}</td>

--- a/app/templates/rents_basic.html
+++ b/app/templates/rents_basic.html
@@ -27,11 +27,12 @@
                     <td style="width: 8.00%">{{ item.rentcode }}</td>
                     <td style="width: 9.00%"> {{ item.rentpa }}</td>
                     <td style="width: 8.00%"> {{ item.arrears }}</td>
-                    <td style="width: 13.00%"> {{ item.nextrentdate.strftime('%d-%b-%Y') }}</td>
+                    <td style="width: 13.00%"> {{ next_rent_date(item.lastrentdate, item.freq_id,
+                        item.datecode_id, 1).strftime('%d-%b-%Y') }}</td>
                     <td style="width: 15.00%"> {{ item.tenantname }}</td>
                     <td style="width: 22.00%">{{ item.propaddr }}</td>
                     <td style="width: 8.00%"> {{ item.source }}</td>
-                    <td style="width: 15.00%"> {{ item.agent.detail | default('no agent', true) | truncate(40) }}
+                    <td style="width: 15.00%"> {{ item.detail | default('no agent', true) | truncate(40) }}
                     </td>
                     <td style="width: 2.00%" class="vertical-align"><a href="{{ url_for('rent_bp.rent',
             rent_id=item.id) }}" class="btn btn-teal-light btn-round button-icon round circles"

--- a/app/views/headrent.py
+++ b/app/views/headrent.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, redirect, render_template, request, url_for
 from flask_login import login_required
 from app.dao.headrent import get_headrent
-from app.main.common import get_combodict_basic, inc_date_m
+from app.main.common import get_combodict_basic
 from app.main.headrent import get_headrents_p, update_headrent
 from app.modeltypes import HrStatuses
 
@@ -22,9 +22,7 @@ def headrent(headrent_id):
         update_headrent(headrent_id)
         return redirect(url_for('headrent_bp.headrent', headrent_id=headrent_id))
     headrent = get_headrent(headrent_id)
-    headrent.nextrentdate = inc_date_m(headrent.lastrentdate, headrent.freq_id, headrent.datecode_id, 1)
     headrent.status = HrStatuses.get_name(headrent.status_id)
     combodict = get_combodict_basic()
-    nextrentdate = inc_date_m(headrent.lastrentdate, headrent.freq_id, headrent.datecode_id, 1)
 
-    return render_template('headrent.html', combodict=combodict, headrent=headrent, nextrentdate=nextrentdate)
+    return render_template('headrent.html', combodict=combodict, headrent=headrent)

--- a/app/views/rent.py
+++ b/app/views/rent.py
@@ -3,8 +3,8 @@ from flask_login import login_required
 from app.dao.common import get_filters
 from app.dao.rent import get_rent_external
 from app.main.common import get_combodict_filter, get_combodict_rent
-from app.main.rent import get_rentp, get_rents_advanced, get_rents_basic, get_rents_external, get_rent_strings, \
-    rent_validation, update_rent_rem, update_tenant
+from app.main.rent import get_rentp, get_rents_advanced, get_rents_basic, get_rents_basic_sql, get_rents_external, \
+    get_rent_strings, rent_validation, update_rent_rem, update_tenant
 
 rent_bp = Blueprint('rent_bp', __name__)
 
@@ -34,15 +34,6 @@ def rent(rent_id):
     return render_template('rent.html', rent=rent, combodict=combodict, rentstats=rentstats, messages=messages)
 
 
-@rent_bp.route('/', methods=['GET', 'POST'])
-@rent_bp.route('/rents_basic', methods=['GET', 'POST'])
-@login_required
-def rents_basic():  # get rents_basic for home rents_basic page with simple search option
-    fdict, rents = get_rents_basic()
-
-    return render_template('rents_basic.html', fdict=fdict, rents=rents)
-
-
 @rent_bp.route('/rent_external/<int:rent_external_id>', methods=["GET"])
 @login_required
 def rent_external(rent_external_id):  # view external rent from home rents page
@@ -60,6 +51,15 @@ def rents_advanced(filtr_id):  # get rents for advanced queries page and pr page
 
     return render_template('rents_advanced.html', action=action, combodict=combodict, filtr_id=filtr_id,
                            fdict=fdict, rents=rents)
+
+
+@rent_bp.route('/', methods=['GET', 'POST'])
+@rent_bp.route('/rents_basic', methods=['GET', 'POST'])
+@login_required
+def rents_basic():  # get rents_basic for home rents_basic page with simple search option
+    fdict, rents = get_rents_basic_sql()
+
+    return render_template('rents_basic.html', fdict=fdict, rents=rents)
 
 
 @rent_bp.route('/rents_external', methods=['GET', 'POST'])


### PR DESCRIPTION
but note that I am experimenting with a raw sql query for rents_basic as
an alternative to our several sqlalchemy queries, none of which I can
get to work fully. I am sure one of us may be able to overcome our
joint disability on this front, but, at the moment, my raw sql query
works much faster and much better than any ORM alternative I have tried.

I have introduced a global function next_rent_date() which can be
called in any html template.  It is a pity it takes four parameters,
but it is used all over mjinn and I am confident it is the right way to
go.

I have dropped date_m from models.py and from my db and suggest you drop
the table from your db.

I am not sure where J is up to with HR statuses, as I think line 25 in
views.headrent.py should be removed if this value is available globally.

I think we may be able  get rid of all combodicts in main.common and
also, hopefully, get__rents_fdict, if my work in main.rent_filter comes
to fruition.